### PR TITLE
docker: Rewritten Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,43 @@
-FROM golang:1.13-alpine as myiac-builder
-RUN apk add --no-cache git bash sudo curl
-WORKDIR /go/src/github.com/dfernandezm/myiac
-COPY . .
-RUN go get -d -v ./...
-RUN go install -v ./...
+FROM golang:1.15-alpine as myiac-builder
+
+ADD . /workdir
+
+RUN \
+    cd /workdir && \
+    go build -o /usr/bin/myiac cmd/myiac/myiac.go
 
 FROM google/cloud-sdk:alpine
-RUN apk --update add openjdk7-jre
-RUN gcloud components install kubectl
-ENV TERRAFORM_VERSION=0.12.17
-RUN apk update && \
-    apk add curl jq python bash ca-certificates git openssl unzip wget util-linux vim && \
+COPY --from=myiac-builder /usr/bin/myiac /usr/bin/myiac
+
+ENV TERRAFORM_VERSION=0.12.29 \
+    HELM_VERSION=3.1.2
+
+RUN \
+    apk --update add \
+        openjdk7-jre \
+        curl \
+        jq \
+        bash \
+        ca-certificates \
+        git \
+        openssl \
+        unzip \
+        wget \
+        util-linux \
+        vim && \
+    gcloud components install kubectl && \
     cd /tmp && \
     wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
-RUN wget https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz && \
-    tar -zxvf helm-v2.16.1-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /usr/bin
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin && \
+    rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    mv linux-amd64/helm /usr/bin && \
+    rm -f helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    addgroup -S app && adduser -S app -G app -h /home/app && \
+    chown app:app /usr/bin/myiac && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
 
-# https://stackoverflow.com/questions/49955097/how-do-i-add-a-user-when-im-using-alpine-as-a-base-image
-
-RUN addgroup -S app && adduser -S app -G app -h /home/app
 USER app
-RUN mkdir -p /home/app
-WORKDIR /home/app
-COPY --from=myiac-builder /go/bin/myiac .
-COPY --chown=app:app account.json .
-COPY --chown=app:app internal/helperScripts helperScripts
-COPY --chown=app:app charts charts
-COPY --chown=app:app entrypoint.sh /home/app
-RUN chmod +x /home/app/entrypoint.sh
-CMD /home/app/entrypoint.sh
 
+CMD ['/usr/bin/myiac']


### PR DESCRIPTION
### Changes:

- Fixed `Dockerfile` so the container is built and accepts `myiac` command
- Streamlined the build process to have much fewer layers. 
- Tidy up `tar` and `zip` files and cleaned `apk` cache to slim the image down

### Tests:

```
 => [internal] load build definition from Dockerfile                                                                      0.0s
 => => transferring dockerfile: 1.30kB                                                                                    0.0s
 => [internal] load .dockerignore                                                                                         0.0s
 => => transferring context: 2B                                                                                           0.0s
 => [internal] load metadata for docker.io/google/cloud-sdk:alpine                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.15-alpine                                                     0.0s
 => [internal] load build context                                                                                         0.0s
 => => transferring context: 11.07kB                                                                                      0.0s
 => CACHED [myiac-builder 1/3] FROM docker.io/library/golang:1.15-alpine                                                  0.0s
 => [stage-1 1/3] FROM docker.io/google/cloud-sdk:alpine                                                                  0.0s
 => [myiac-builder 2/3] ADD . /workdir                                                                                    0.4s
 => [myiac-builder 3/3] RUN     cd /workdir &&     go build -o /usr/bin/myiac cmd/myiac/myiac.go                         21.7s
 => CACHED [stage-1 2/3] COPY --from=myiac-builder /usr/bin/myiac /usr/bin/myiac                                          0.0s
 => [stage-1 3/3] RUN     apk --update add         openjdk7-jre         curl         jq         bash         ca-certif  107.2s 
 => exporting to image                                                                                                   12.0s 
 => => exporting layers                                                                                                  12.0s 
 => => writing image sha256:511350d0a0a5105fa2dfb9c4e0a0724d90e353b0083af997fe2fdea5444ee567                              0.0s 
 => => naming to docker.io/library/test 
```