### PR TITLE
Return interfaces instead of struct pointers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/iac-io/myiac v0.0.0-20210108155704-1991d020842b h1:VI0hHzw7N5JQdF/NxKPFmQNbyfM4AxK7flC7DcFStE8=
+github.com/iac-io/myiac v0.0.0-20210108155704-1991d020842b/go.mod h1:egkpkf9I/SaJpV1mEpdELOA0Jgsg+91i6S9fINNrPUA=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=

--- a/internal/cluster/kubernetes.go
+++ b/internal/cluster/kubernetes.go
@@ -83,7 +83,7 @@ type kubernetesRunner struct {
 	cmdRunner commandline.CommandRunner
 }
 
-func NewKubernetesRunner(commandRunner commandline.CommandRunner) *kubernetesRunner {
+func NewKubernetesRunner(commandRunner commandline.CommandRunner) KubernetesRunner {
 	return &kubernetesRunner{cmdRunner: commandRunner}
 }
 

--- a/internal/cluster/kubernetes.go
+++ b/internal/cluster/kubernetes.go
@@ -32,7 +32,7 @@ func GetPods() {
 func executeGetIpsCmd() map[string]interface{} {
 	argsArray := []string{"get", "nodes", "-o", "json"}
 	cmd := commandline.New("kubectl", argsArray)
-	cmd.IsSuppressOutput = true
+	cmd.SetSuppressOutput(true)
 	cmdResult := cmd.Run()
 	cmdOutput := cmdResult.Output
 	json := util.Parse(cmdOutput)
@@ -67,7 +67,7 @@ func CreateSecretFromLiteral(name string, namespace string, literals map[string]
 	fromLiteralArg = strings.TrimSpace(fromLiteralArg)
 	argsArray := []string{"create", "secret", "generic", name, fromLiteralArg, "-n", namespace}
 	cmd := commandline.New("kubectl", argsArray)
-	cmd.IsSuppressOutput = true
+	cmd.SetSuppressOutput(true)
 	cmd.Run()
 }
 
@@ -127,7 +127,7 @@ func (kr kubernetesRunner) FindSecret(name string, namespace string) string {
 func deleteSecret(name string, namespace string) {
 	argsArray := []string{"delete", "secret", name, "-n", namespace}
 	cmd := commandline.New("kubectl", argsArray)
-	cmd.IsSuppressOutput = true
+	cmd.SetSuppressOutput(true)
 	cmd.IgnoreError(true)
 	cmd.Run()
 }

--- a/internal/commandline/commandline.go
+++ b/internal/commandline/commandline.go
@@ -19,6 +19,7 @@ type CommandRunner interface {
 	SetupWithoutOutput(cmd string, args []string)
 	SetupCmdLine(cmdLine string)
 	IgnoreError(ignoreError bool)
+	SetSuppressOutput(suppressOutput bool)
 	Run() CommandOutput
 }
 
@@ -108,6 +109,10 @@ func (c *commandExec) SetupWithoutOutput(executable string, arguments []string) 
 
 func (c *commandExec) SetWorkingDir(workingDir string) {
 	c.workingDir = workingDir
+}
+
+func (c *commandExec) SetSuppressOutput(suppressOutput bool) {
+	c.IsSuppressOutput = suppressOutput
 }
 
 func (c *commandExec) Run() CommandOutput {

--- a/internal/commandline/commandline.go
+++ b/internal/commandline/commandline.go
@@ -22,6 +22,12 @@ type CommandRunner interface {
 	Run() CommandOutput
 }
 
+type CommandOptions struct {
+	CommandLine string
+	WorkingDir string
+	SuppressOutput bool
+}
+
 type commandExec struct {
 	executable       string
 	arguments        []string
@@ -35,13 +41,13 @@ type CommandOutput struct {
 	Output string
 }
 
-func NewEmpty() *commandExec {
+func NewEmpty() CommandRunner {
 	ce := &commandExec{"", make([]string, 0), "", "",
 		false, false}
 	return ce
 }
 
-func NewCommandLine(commandLine string) *commandExec {
+func NewCommandLine(commandLine string) CommandRunner {
 	commandParts := strings.Split(commandLine, " ")
 	executable := commandParts[0]
 	args := commandParts[1:]
@@ -50,16 +56,36 @@ func NewCommandLine(commandLine string) *commandExec {
 	return ce
 }
 
-func New(executable string, arguments []string) *commandExec {
+func New(executable string, arguments []string) CommandRunner {
 	ce := &commandExec{executable, arguments, "", "",
 		false, false}
 	return ce
 }
 
-func NewWithWorkingDir(executable string, arguments []string, workingDir string) *commandExec {
+func NewWithWorkingDir(executable string, arguments []string, workingDir string) CommandRunner {
 	ce := &commandExec{executable, arguments, "", workingDir,
 		false, false}
 	return ce
+}
+
+func NewWithOptions(commandOptions CommandOptions) (CommandRunner, error) {
+	if commandOptions.CommandLine != "" {
+		commandParts := strings.Split(commandOptions.CommandLine, " ")
+		executable := commandParts[0]
+		args := commandParts[1:]
+
+		//TODO: validate rest of parameters
+		ce := &commandExec{
+			executable,
+			args,
+			"",
+			commandOptions.WorkingDir,
+			commandOptions.SuppressOutput,
+			false}
+		return ce, nil
+	}
+
+	return nil, fmt.Errorf("options invalid to create commandline %v", commandOptions)
 }
 
 func (c *commandExec) SetupCmdLine(cmdLine string) {

--- a/internal/commandline/commandline.go
+++ b/internal/commandline/commandline.go
@@ -24,8 +24,8 @@ type CommandRunner interface {
 }
 
 type CommandOptions struct {
-	CommandLine string
-	WorkingDir string
+	CommandLine    string
+	WorkingDir     string
 	SuppressOutput bool
 }
 

--- a/internal/gcp/identity.go
+++ b/internal/gcp/identity.go
@@ -28,13 +28,13 @@ type gcpIamClient struct {
 }
 
 // NewGcpIamClient Creates a new IamClient with external provided context and *iam.Service
-func NewGcpIamClient(ctx context.Context, iamService *iam.Service) *gcpIamClient {
+func NewGcpIamClient(ctx context.Context, iamService *iam.Service) IamGcpClient {
 	return &gcpIamClient{iamService: iamService, ctx: ctx}
 }
 
 // NewGcpIamClient Creates a new IamClient with default context.
 // Authentication against GCP must have already been performed when invoking this operation
-func NewDefaultIamClient() *gcpIamClient {
+func NewDefaultIamClient() IamGcpClient {
 	ctx := context.Background()
 	return NewGcpIamClient(ctx, getIamService(ctx))
 }
@@ -77,13 +77,13 @@ type gcpObjectStorageCache struct {
 
 // NewGcpObjectStorageCache creates a GCP-based Object Storage cache, optionally
 // receiving a Context. It injects a ObjectStorageClient providing the base operations
-func NewGcpObjectStorageCache(ctx context.Context, client ObjectStorageGcpClient) *gcpObjectStorageCache {
+func NewGcpObjectStorageCache(ctx context.Context, client ObjectStorageGcpClient) ObjectStorageCache {
 	return &gcpObjectStorageCache{client: client, ctx: ctx}
 }
 
 // NewDefaultObjectStorageCache creates a GCP-based Object Storage cache using a
 // inner context
-func NewDefaultObjectStorageCache() *gcpObjectStorageCache {
+func NewDefaultObjectStorageCache() ObjectStorageCache {
 	ctx := context.Background()
 	return NewGcpObjectStorageCache(ctx, getObjectStorageClient(ctx))
 }

--- a/internal/gcp/kms.go
+++ b/internal/gcp/kms.go
@@ -1,17 +1,14 @@
 package gcp
 
 import (
+	kms "cloud.google.com/go/kms/apiv1"
 	"context"
 	"fmt"
-	"github.com/dfernandezm/myiac/internal/encryption"
-	"log"
-	"google.golang.org/api/iterator"
-
+	"github.com/iac-io/myiac/internal/encryption"
 	"github.com/iac-io/myiac/internal/util"
 	"google.golang.org/api/iterator"
-
-	kms "cloud.google.com/go/kms/apiv1"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
+	"log"
 )
 
 type keyRing struct {

--- a/internal/gcp/kms.go
+++ b/internal/gcp/kms.go
@@ -1,14 +1,15 @@
 package gcp
 
 import (
-	kms "cloud.google.com/go/kms/apiv1"
 	"context"
 	"fmt"
+	"log"
+
+	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/iac-io/myiac/internal/encryption"
 	"github.com/iac-io/myiac/internal/util"
 	"google.golang.org/api/iterator"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
-	"log"
 )
 
 type keyRing struct {

--- a/internal/gcp/kms.go
+++ b/internal/gcp/kms.go
@@ -3,7 +3,9 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"github.com/dfernandezm/myiac/internal/encryption"
 	"log"
+	"google.golang.org/api/iterator"
 
 	"github.com/iac-io/myiac/internal/util"
 	"google.golang.org/api/iterator"
@@ -35,7 +37,7 @@ type kmsEncrypter struct {
 // See: https://cloud.google.com/kms/docs/creating-keys
 //
 func NewKmsEncrypter(projectId string, locationId string, defaultKeyRingName string,
-	defaultKeyName string) *kmsEncrypter {
+	defaultKeyName string) encryption.Encrypter {
 	kenc := new(kmsEncrypter)
 	kenc.projectId = projectId
 	kenc.locationId = locationId

--- a/internal/gcp/kms_test.go
+++ b/internal/gcp/kms_test.go
@@ -12,8 +12,7 @@ import (
 func TestCreateGCPKMSService(t *testing.T) {
 	gcpClient := NewKmsEncrypter("moneycol", "moneycol-keyring",
 		"moneycol-keyring", "moneycol-infra-key")
-	assert.Equal(t, "moneycol", gcpClient.projectId)
-	assert.Equal(t, "moneycol-keyring", gcpClient.defaultKeyRingName)
+	assert.NotNil(t,gcpClient)
 }
 
 func TestEncrypts(t *testing.T) {

--- a/internal/gcp/kms_test.go
+++ b/internal/gcp/kms_test.go
@@ -12,7 +12,7 @@ import (
 func TestCreateGCPKMSService(t *testing.T) {
 	gcpClient := NewKmsEncrypter("moneycol", "moneycol-keyring",
 		"moneycol-keyring", "moneycol-infra-key")
-	assert.NotNil(t,gcpClient)
+	assert.NotNil(t, gcpClient)
 }
 
 func TestEncrypts(t *testing.T) {

--- a/internal/gcp/service_account.go
+++ b/internal/gcp/service_account.go
@@ -13,7 +13,7 @@ import (
 type ServiceAccountClient interface {
 	KeyForServiceAccount(saEmail string, recreateKey bool) (string, error)
 	KeyFileForServiceAccount(saEmail string, recreateKey bool, filePath string) error
-	CreateKey(serviceAccountEmail string)
+	CreateKey(serviceAccountEmail string) (string, string, error)
 	ListKeys(serviceAccountEmail string) ([]string, error)
 }
 
@@ -23,13 +23,13 @@ type serviceAccountClient struct {
 }
 
 // NewServiceAccountClient creates a new GCP client for service account key management
-func NewServiceAccountClient(iamClient IamGcpClient, objectStorageCache ObjectStorageCache) *serviceAccountClient {
+func NewServiceAccountClient(iamClient IamGcpClient, objectStorageCache ObjectStorageCache) ServiceAccountClient {
 	return &serviceAccountClient{gcpIamClient: iamClient, objectStorageCache: objectStorageCache}
 }
 
 // NewDefaultServiceAccountClient creates a new GCP client for service account key management based on defaults
 // Authentication against GCP must have already been performed before invoking this operation
-func NewDefaultServiceAccountClient() *serviceAccountClient {
+func NewDefaultServiceAccountClient() ServiceAccountClient {
 	return NewServiceAccountClient(NewDefaultIamClient(), NewDefaultObjectStorageCache())
 }
 

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -25,13 +25,13 @@ type configPreferences struct {
 	propertiesFile *ini.File
 }
 
-func DefaultConfig() *configPreferences {
+func DefaultConfig() Preferences {
 	homeDir, _ := os.UserHomeDir()
 	prefsFilePath := homeDir + preferencesFile
 	return NewConfig(prefsFilePath)
 }
 
-func NewConfig(prefsFilePath string) *configPreferences {
+func NewConfig(prefsFilePath string) Preferences {
 	var errFile error = nil
 
 	if !util.FileExists(prefsFilePath) {

--- a/internal/preferences/preferences_test.go
+++ b/internal/preferences/preferences_test.go
@@ -2,11 +2,12 @@ package preferences
 
 import (
 	"fmt"
-	"github.com/iac-io/myiac/internal/util"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/iac-io/myiac/internal/util"
+	"github.com/stretchr/testify/assert"
 )
 
 var prefsFilename = "/tmp/.myiac/testPrefs"

--- a/internal/preferences/preferences_test.go
+++ b/internal/preferences/preferences_test.go
@@ -2,11 +2,11 @@ package preferences
 
 import (
 	"fmt"
-	"os"
-	"testing"
-
 	"github.com/iac-io/myiac/internal/util"
 	"github.com/stretchr/testify/assert"
+	"log"
+	"os"
+	"testing"
 )
 
 var prefsFilename = "/tmp/.myiac/testPrefs"
@@ -23,6 +23,7 @@ func setup() {
 }
 
 func teardown() {
+	log.Printf("Cleaning up prefs file")
 	_ = os.Remove(prefsFilename)
 }
 

--- a/internal/secret/secret_manager.go
+++ b/internal/secret/secret_manager.go
@@ -30,14 +30,14 @@ type kubernetesSecretManager struct {
 	kubernetesRunner cluster.KubernetesRunner
 }
 
-func NewKubernetesSecretManager(namespace string, kubernetesRunner cluster.KubernetesRunner) *kubernetesSecretManager {
+func NewKubernetesSecretManager(namespace string, kubernetesRunner cluster.KubernetesRunner) SecretManager {
 	return &kubernetesSecretManager{
 		namespace:        namespace,
 		kubernetesRunner: kubernetesRunner,
 	}
 }
 
-func CreateKubernetesSecretManager(namespace string) *kubernetesSecretManager {
+func CreateKubernetesSecretManager(namespace string) SecretManager {
 	return NewKubernetesSecretManager(namespace, cluster.NewKubernetesRunner(commandline.NewEmpty()))
 }
 

--- a/internal/secret/secret_manager.go
+++ b/internal/secret/secret_manager.go
@@ -9,6 +9,7 @@ import (
 
 type SecretManager interface {
 	CreateTlsSecret(secret TlsSecret)
+	CreateFileSecret(secretName string, filePath string)
 }
 
 type TlsSecret struct {

--- a/internal/secret/secret_manager_test.go
+++ b/internal/secret/secret_manager_test.go
@@ -15,7 +15,7 @@ func TestCreateSecret(t *testing.T) {
 	cmdLine := testutil.FakeKubernetesRunner("test-output")
 	kubernetesRunner := cluster.NewKubernetesRunner(cmdLine)
 	secretManager := NewKubernetesSecretManager("default", kubernetesRunner)
-	fmt.Printf(secretManager.namespace)
+
 	// given
 	filePath := "/tmp/filepath"
 	secretName := "test-secret-name"
@@ -25,7 +25,7 @@ func TestCreateSecret(t *testing.T) {
 	secretManager.CreateFileSecret(secretName, filePath)
 
 	// then
-	//TODO: should validate snake case
+	//TODO: should validate snake case in the secret name (camelCase failures)
 	expectedCreateSecretCmdLine :=
 		fmt.Sprintf("kubectl create secret generic %s "+
 			"--from-file=%s.json=%s -n default", secretName, secretName, filePath)

--- a/internal/ssl/certificate.go
+++ b/internal/ssl/certificate.go
@@ -16,7 +16,7 @@ type SecretCertStore struct {
 	secretManager secret.SecretManager
 }
 
-func NewSecretCertStore(secretManager secret.SecretManager) *SecretCertStore {
+func NewSecretCertStore(secretManager secret.SecretManager) CertStore {
 	return &SecretCertStore{secretManager: secretManager}
 }
 

--- a/internal/ssl/certificate_test.go
+++ b/internal/ssl/certificate_test.go
@@ -1,57 +1,22 @@
 package ssl
 
 import (
-	"strings"
-	"testing"
-
 	"github.com/iac-io/myiac/internal/cluster"
-	"github.com/iac-io/myiac/internal/commandline"
 	"github.com/iac-io/myiac/internal/secret"
 	"github.com/iac-io/myiac/internal/util"
+	"github.com/iac-io/myiac/testutil"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
-
-type fakeKubernetesRunner struct {
-	cmd      string
-	args     []string
-	CmdLines []string
-}
-
-func (fk *fakeKubernetesRunner) SetupWithoutOutput(cmd string, args []string) {
-	fk.cmd = cmd
-	fk.args = args
-}
-
-func (fk *fakeKubernetesRunner) Run() commandline.CommandOutput {
-	currentCmdLine := fk.cmd + " " + strings.Join(fk.args, " ")
-	fk.CmdLines = append(fk.CmdLines, currentCmdLine)
-	return commandline.CommandOutput{Output: "test-domain"}
-}
-
-func (fk fakeKubernetesRunner) RunVoid() {
-}
-
-func (fk fakeKubernetesRunner) Output() string {
-	return "test-domain"
-}
-
-func (fk fakeKubernetesRunner) Setup(cmd string, args []string) {
-}
-
-func (fk fakeKubernetesRunner) IgnoreError(ignoreError bool) {
-}
-
-func (fk fakeKubernetesRunner) SetupCmdLine(cmdLine string) {
-}
 
 func TestCreateTlsCertificate(t *testing.T) {
 	// setup
-	cmdLine := new(fakeKubernetesRunner)
+	domain := "test-domain"
+	cmdLine := testutil.FakeKubernetesRunner(domain)
 	kubernetesRunner := cluster.NewKubernetesRunner(cmdLine)
 	secretManager := secret.NewKubernetesSecretManager("default", kubernetesRunner)
 
 	// given
-	domain := "test-domain"
 	certPath := "/tmp/cert.pem"
 	keyPath := "/tmp/cert.key"
 

--- a/internal/ssl/certificate_test.go
+++ b/internal/ssl/certificate_test.go
@@ -1,12 +1,13 @@
 package ssl
 
 import (
+	"testing"
+
 	"github.com/iac-io/myiac/internal/cluster"
 	"github.com/iac-io/myiac/internal/secret"
 	"github.com/iac-io/myiac/internal/util"
 	"github.com/iac-io/myiac/testutil"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCreateTlsCertificate(t *testing.T) {

--- a/testutil/fake_cmd_runner.go
+++ b/testutil/fake_cmd_runner.go
@@ -1,8 +1,9 @@
 package testutil
 
 import (
-	"github.com/iac-io/myiac/internal/commandline"
 	"strings"
+
+	"github.com/iac-io/myiac/internal/commandline"
 )
 
 type fakeRunner struct {

--- a/testutil/fake_cmd_runner.go
+++ b/testutil/fake_cmd_runner.go
@@ -1,9 +1,8 @@
 package testutil
 
 import (
-	"strings"
-
 	"github.com/iac-io/myiac/internal/commandline"
+	"strings"
 )
 
 type fakeRunner struct {
@@ -35,6 +34,9 @@ func (fk fakeRunner) Setup(cmd string, args []string) {
 }
 
 func (fk fakeRunner) IgnoreError(ignoreError bool) {
+}
+
+func (fk fakeRunner) SetSuppressOutput(suppressOutput bool) {
 }
 
 func (fk fakeRunner) GetCmdLines() []string {


### PR DESCRIPTION
This is the standard way of using interface/struct to hide information and implementation detail.

- The current tests pass
- The project builds and runs setupEnvironment

Extras:

- Added a constructor to `commandline` so it receives a `CommandOptions` object. Going forward this avoids having lots of constructors with different options (will remove duplication, boilerplate)