### PR TITLE
bug: terraform: node-pool: shortened pool name to have default-pool name

### DIFF
--- a/internal/cli/create_secret.go
+++ b/internal/cli/create_secret.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/iac-io/myiac/internal/cluster"
 	"github.com/iac-io/myiac/internal/gcp"
 	"github.com/iac-io/myiac/internal/secret"
 	"github.com/urfave/cli"

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -62,13 +62,8 @@ func ApplyTerraform(tp string, tf string) {
 func CreateCluster(provider string, project string, env string, zone string, dryrun bool, key string) error {
 	InitTerraform(tfvarsPath, project, env)
 	if dryrun {
-		log.Printf("Authenticating only due to --dry-run: %v", project+"-"+env)
-		SetupProvider(provider, zone, project+"-"+env, project, key, dryrun)
 		PlanTerraform(tfvarsPath, tfvarsFile)
 	} else {
-		// Set local env kube for local connectivity to new cluster
-		log.Printf("Setting kubectl to work with new cluster: %v", project+"-"+env)
-		SetupProvider(provider, zone, project+"-"+env, project, key, dryrun)
 		ApplyTerraform(tfvarsPath, tfvarsFile)
 	}
 

--- a/internal/terraform/cluster/cluster.tfvars
+++ b/internal/terraform/cluster/cluster.tfvars
@@ -4,8 +4,8 @@ cluster_zone                 = "europe-west2-b"
 cluster_state_bucket         = "ozzy-playground-tfstate-dev"
 state_bucket_prefix          = "terraform/state/cluster"
 applications_machine_type    = "n1-standard-2"
-elasticsearch_machine_type   = "n1-standard-1"
 applications_max_node_count  = 3
-elasticsearch_max_node_count = 1
+k8s_master_version           = "1.17.15-gke.800"
+k8s_node_pool_version        = "1.17.15-gke.800"
 //terraform apply -var-file="cluster.tfvars" 
 //https://github.com/jetstack/terraform-google-gke-cluster/blob/master/example/main.tf

--- a/internal/terraform/cluster/variables.tf
+++ b/internal/terraform/cluster/variables.tf
@@ -22,16 +22,14 @@ variable "applications_machine_type" {
   type = string
 }
 
-variable "elasticsearch_machine_type" {
-  type = string
-}
-
 variable "applications_max_node_count" {
   type = string
 }
 
-variable "elasticsearch_max_node_count" {
-  type = number
+variable "k8s_master_version" {
+  type = string
 }
 
-
+variable "k8s_node_pool_version" {
+  type = string
+}


### PR DESCRIPTION
### Changes: 

- Changed `terraform` `pool-name` to `default-pool` - Since it's generic cluster we don't need custom name (Fixes #51 )
- Bumped `k8s` to the latest GCP version
- Removed Elasticsearch config from generic terraform config
- Tidy up createCluster

### Tests

tested create/destroy with `--dry-run` option enabled and without. 

All Passed