### PR TITLE
Custom helm path added to the script

### DIFF
--- a/start-dev-env.sh
+++ b/start-dev-env.sh
@@ -6,10 +6,18 @@ else
   TERRAFORM_PATH=${2}
 fi
 
+if [ -z "${3}" ]; then
+  HELM_PATH=""
+else
+  HELM_PATH="-v ${3}:/helm"
+fi
+
+
 docker run -ti --rm \
   --name myiac \
   -v ${PWD}/:/workdir \
   -w /workdir \
   -v ${1}:/account.json \
   -v ${TERRAFORM_PATH}/:/terraform \
+  ${HELM_PATH} \
   myiac:latest zsh


### PR DESCRIPTION
### Changes: 

- added custom `helm` path for `start-dev-env.sh`. Mounts into `/helm` [ Fix #67 ]

### Tests:

```
./start-dev-env.sh ~/my_Key.json ${PWD}/terraform ${PWD}/helm
[powerlevel10k] fetching gitstatusd .. [ok]                                                                                   
❯ ls -lah /helm
total 8K     
drwxr-xr-x    4 app      app          128 Jan 19 10:42 .
drwxr-xr-x    1 root     root        4.0K Jan 19 15:43 ..
-rw-r--r--    1 app      app         2.4K Jan 19 10:42 README.md
drwxr-xr-x    5 app      app          160 Jan 19 10:42 charts
```