### PR TITLE
resizePool Option

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -21,7 +21,8 @@ RUN \
         zsh \
         go \
         busybox-extras \
-        mtr && \
+        mtr \
+        sed && \
     gcloud components install kubectl && \
     cd /tmp && \
     wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/Dockerfiles/container-files/home/app/.p10k.zsh
+++ b/Dockerfiles/container-files/home/app/.p10k.zsh
@@ -59,7 +59,7 @@
     nvm                     # node.js version from nvm (https://github.com/nvm-sh/nvm)
     nodeenv                 # node.js environment (https://github.com/ekalinin/nodeenv)
     # node_version          # node.js version
-    # go_version            # go version (https://golang.org)
+    go_version              # go version (https://golang.org)
     # rust_version          # rustc version (https://www.rust-lang.org)
     # dotnet_version        # .NET version (https://dotnet.microsoft.com)
     # php_version           # php version (https://www.php.net/)
@@ -101,7 +101,7 @@
     # =========================[ Line #2 ]=========================
     newline                 # \n
     # ip                    # ip address and bandwidth usage for a specified network interface
-    # public_ip             # public IP address
+    public_ip             # public IP address
     # proxy                 # system-wide http/https/ftp proxy
     # battery               # internal battery
     # wifi                  # wifi speed

--- a/Dockerfiles/container-files/home/app/.zshrc
+++ b/Dockerfiles/container-files/home/app/.zshrc
@@ -68,7 +68,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git kubectl gcloud helm golang)
+plugins=(git kubectl gcloud helm)
 
 source $ZSH/oh-my-zsh.sh
 

--- a/Dockerfiles/container-files/home/app/.zshrc
+++ b/Dockerfiles/container-files/home/app/.zshrc
@@ -68,7 +68,7 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git)
+plugins=(git kubectl gcloud helm golang)
 
 source $ZSH/oh-my-zsh.sh
 
@@ -101,6 +101,7 @@ source $ZSH/oh-my-zsh.sh
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
-alias kp='kube-prompt'
-alias c='clear'
-alias ll='ls -lah'
+alias kp="kube-prompt"
+alias c="clear"
+alias ll="ls -lah"
+alias vi="vim"

--- a/internal/cluster/provider.go
+++ b/internal/cluster/provider.go
@@ -57,9 +57,14 @@ func NewGcpProvider(projectId string, keyLocation string, gkeCluster GkeCluster)
 func (gcp *GcpProvider) Setup() {
 	setupDone := gcp.checkSetup()
 	if !setupDone {
+		// Activate account
 		cmdLine := fmt.Sprintf("gcloud auth activate-service-account --key-file %s", gcp.keyLocation)
 		cmd := commandline.NewCommandLine(cmdLine)
 		cmdOutput := cmd.Run()
+		// Authenticate with GCP
+		AuthCmd := fmt.Sprintf("gcloud config set project %s", gcp.projectId)
+		cmd1 := commandline.NewCommandLine(AuthCmd)
+		cmd1.Run()
 		gcp.masterSaEmail = extractServiceAccountEmail(cmdOutput.Output)
 		gcp.savePreferences()
 	}


### PR DESCRIPTION
### Changes: 

- Added `resizePool` option for easy i nteraction with specific pool
- Updated local `.zshrc` to print `GoLang` version in dev-env docker image
- Fixe typo in `dryRunFlag` variable
- Added authenticate to FCP Setup which was missing. 
- `creteCluster` and `resizePool` options require `--zone` argument

### Tests:
Dev-Env Docker image prompt with additional info `GoLang` version and external `IP` address 

```
╭─   /workdir   feature/resizePool *3 ───────────────────────────────────────────────────────────────────────  1.13.15 ─╮
╰─❯                                                                                                          87.138.156.102 ─╯
```
---
`resizePool`

```
INFO: Display format: "default"

2021/01/21 10:27:36 Node Pool: production resized to 3 nodes
```
