### PR TITLE
Fix for wrong service account auth + extraction/refactor auth

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,6 @@ echo "====== Startup script Daemonset ====="
 do_startup_script() {
   local err=0;
   bash -c  "${STARTUP_SCRIPT}" && err=0 || err=$?
-  #"${EXEC[@]}" bash -c "${STARTUP_SCRIPT}" && err=0 || err=$?
   if [[ ${err} != 0 ]]; then
     echo "!!! startup-script failed! exit code '${err}'" 1>&2
     return 1
@@ -30,10 +29,6 @@ do_startup_script() {
 }
 
 while :; do
-  #"${EXEC[@]}" stat "${CHECKPOINT_PATH}" > /dev/null 2>&1 && err=0 || err=$?
-  #if [[ ${err} != 0 ]]; then
   do_startup_script
-  #fi
-
   sleep "${CHECK_INTERVAL_SECONDS}"
 done

--- a/internal/cluster/provider.go
+++ b/internal/cluster/provider.go
@@ -164,6 +164,8 @@ func (gp gcpProvider) ClusterSetup() {
 	gp.saveGkePreferences(clusterName, zone)
 }
 
+// move to gke.go?
+
 func (gp gcpProvider) savePreferences() {
 	prefs := gp.prefs
 	prefs.Set("provider", gcpProviderName)

--- a/internal/cluster/provider.go
+++ b/internal/cluster/provider.go
@@ -7,7 +7,6 @@ import (
 	"github.com/iac-io/myiac/internal/commandline"
 	"github.com/iac-io/myiac/internal/gcp"
 	"github.com/iac-io/myiac/internal/preferences"
-	"github.com/iac-io/myiac/internal/util"
 )
 
 const (
@@ -67,32 +66,39 @@ func (pf ProviderFactory) getProvider() Provider {
 }
 
 type gcpProvider struct {
-	projectId  string
-	saKey      *gcp.ServiceAccountKey
-	gkeCluster GkeCluster
-	prefs      preferences.Preferences
+	projectId          string
+	serviceAccountAuth gcp.Auth
+	gkeCluster         GkeCluster
+	prefs              preferences.Preferences
+	commandRunner      commandline.CommandRunner
 }
 
 func NewGcpProvider(projectId string, keyLocation string, gkeCluster GkeCluster) *gcpProvider {
-	key, err := gcp.NewServiceAccountKey(keyLocation)
+	return newGcpProvider(commandline.NewEmpty(), projectId, keyLocation, gkeCluster)
+}
+
+func newGcpProvider(commandRunner commandline.CommandRunner, projectId string, keyLocation string,
+	gkeCluster GkeCluster) *gcpProvider {
+	auth, err := gcp.NewServiceAccountAuth(keyLocation)
 
 	if err != nil {
-		log.Fatal(fmt.Errorf("error obtaining key from location %s: %v", keyLocation, err))
+		log.Fatal(fmt.Errorf("error creating service account auth from key %s: %v", keyLocation, err))
 	}
 
 	return &gcpProvider{
-		projectId:  projectId,
-		saKey:      key,
-		gkeCluster: gkeCluster,
-		prefs:      preferences.DefaultConfig(),
+		projectId:          projectId,
+		serviceAccountAuth: auth,
+		gkeCluster:         gkeCluster,
+		prefs:              preferences.DefaultConfig(),
+		commandRunner:      commandRunner,
 	}
 }
 
-// Setup activate master service account from key
+// Setup activates the master service account from a key file
 func (gp *gcpProvider) Setup() {
-	setupDone := gp.checkSetup()
-	if !setupDone {
-		gp.ActivateServiceAccount()
+	log.Printf("Setting up GCP cloud provider authentication...")
+	if !gp.serviceAccountAuth.IsAuthenticated() {
+		gp.serviceAccountAuth.Authenticate()
 		gp.SetProject()
 		gp.savePreferences()
 	}
@@ -102,53 +108,6 @@ func (gp *gcpProvider) SetProject() {
 	cmdLine := fmt.Sprintf("gcloud config set project %s", gp.projectId)
 	cmd := commandline.NewCommandLine(cmdLine)
 	cmd.Run()
-}
-
-func (gp *gcpProvider) ActivateServiceAccount() {
-	cmdLine := fmt.Sprintf("gcloud auth activate-service-account --key-file %s", gp.saKey.KeyFileLocation)
-	cmd := commandline.NewCommandLine(cmdLine)
-	cmd.Run()
-}
-
-func (gp gcpProvider) checkSetup() bool {
-	providedSaEmail := gp.saKey.Email
-	return isAuthenticated(providedSaEmail)
-}
-
-//TODO:  Extract
-
-func isAuthenticated(saEmail string) bool {
-	authList := listActiveAuth()
-	done := isProvidedSaEmailAuthenticated(saEmail, authList)
-	return done
-}
-
-func listActiveAuth() []map[string]interface{} {
-	cmdLine := fmt.Sprintf("gcloud auth list --format json")
-	cmd := commandline.NewCommandLine(cmdLine)
-	cmdOutput := cmd.Run()
-	authList := util.ParseArray(cmdOutput.Output)
-	return authList
-}
-
-func isProvidedSaEmailAuthenticated(providedSaEmail string, authList []map[string]interface{}) bool {
-	log.Printf("Check if already authenticated with SA: %s", providedSaEmail)
-	for _, accountAuth := range authList {
-		saEmail := accountAuth["account"]
-		status := accountAuth["status"]
-
-		log.Printf("Checking account %s", saEmail)
-
-		// at this point we only allow auth using the provided service account key/email
-		// if running inside GCP we would get multiple ACTIVE SAs: the ones of the service this application
-		// is running on
-		if status == "ACTIVE" && (saEmail == providedSaEmail) {
-			log.Printf("Already authenticated for %s\n", saEmail)
-			return true
-		}
-	}
-	log.Printf("Authentication is needed for SA: %s", providedSaEmail)
-	return false
 }
 
 // ClusterSetup gcloud container clusters get-credentials [cluster-name]
@@ -164,14 +123,12 @@ func (gp gcpProvider) ClusterSetup() {
 	gp.saveGkePreferences(clusterName, zone)
 }
 
-// move to gke.go?
-
 func (gp gcpProvider) savePreferences() {
 	prefs := gp.prefs
 	prefs.Set("provider", gcpProviderName)
-	prefs.Set("keyLocation", gp.saKey.KeyFileLocation)
+	prefs.Set("keyLocation", gp.serviceAccountAuth.Key().KeyFileLocation)
+	prefs.Set("masterSaEmail", gp.serviceAccountAuth.Key().Email)
 	prefs.Set("project", gp.projectId)
-	prefs.Set("masterSaEmail", gp.saKey.Email)
 }
 
 func (gp gcpProvider) saveGkePreferences(clusterName string, zone string) {

--- a/internal/gcp/auth.go
+++ b/internal/gcp/auth.go
@@ -1,24 +1,88 @@
 package gcp
 
-import "github.com/iac-io/myiac/internal/commandline"
+import (
+	"fmt"
+	"log"
+
+	"github.com/iac-io/myiac/internal/commandline"
+	"github.com/iac-io/myiac/internal/util"
+)
+
+const (
+	saStatusActive        = "ACTIVE"
+	statusAuthField       = "status"
+	emailAccountAuthField = "account"
+)
+
+type Auth interface {
+	Authenticate()
+	IsAuthenticated() bool
+	Key() *ServiceAccountKey
+}
 
 type ServiceAccountAuth struct {
-	serviceAccountKey ServiceAccountKey
+	ServiceAccountKey *ServiceAccountKey
 	commandRunner     commandline.CommandRunner
 }
 
-func NewServiceAccountAuth(keyLocation string) {
+func NewServiceAccountAuth(keyLocation string) (Auth, error) {
+	saKey, err := NewServiceAccountKey(keyLocation)
 
+	if err != nil {
+		return nil, err
+	}
+
+	return newServiceAccountAuthWithRunner(commandline.NewEmpty(), saKey)
 }
 
-func newServiceAccountAuthWithRunner(commandRunner commandline.CommandRunner, keyLocation string) {
-
+// private constructor that receives commandline (useful for testing)
+func newServiceAccountAuthWithRunner(commandRunner commandline.CommandRunner, accountKey *ServiceAccountKey) (Auth, error) {
+	return &ServiceAccountAuth{ServiceAccountKey: accountKey, commandRunner: commandRunner}, nil
 }
 
-func Authenticate() {
-
+func (saa *ServiceAccountAuth) Authenticate() {
+	keyLocation := saa.ServiceAccountKey.KeyFileLocation
+	cmdLine := fmt.Sprintf("gcloud auth activate-service-account --key-file %s", keyLocation)
+	saa.commandRunner.SetupCmdLine(cmdLine)
+	saa.commandRunner.Run()
 }
 
-func IsAuthenticated() {
+func (saa ServiceAccountAuth) IsAuthenticated() bool {
+	authList := saa.listActiveAuth()
+	done := saa.isServiceAccountEmailAuthenticated(authList)
+	return done
+}
 
+func (saa ServiceAccountAuth) Key() *ServiceAccountKey {
+	return saa.ServiceAccountKey
+}
+
+func (saa ServiceAccountAuth) listActiveAuth() []map[string]interface{} {
+	cmdLine := fmt.Sprintf("gcloud auth list --format json")
+	cmd := commandline.NewCommandLine(cmdLine)
+	cmdOutput := cmd.Run()
+	authList := util.ParseArray(cmdOutput.Output)
+	return authList
+}
+
+func (saa ServiceAccountAuth) isServiceAccountEmailAuthenticated(authList []map[string]interface{}) bool {
+	providedSaEmail := saa.ServiceAccountKey.Email
+
+	log.Printf("Check if already authenticated with SA: %s", providedSaEmail)
+	for _, accountAuth := range authList {
+		saEmail := accountAuth[emailAccountAuthField]
+		status := accountAuth[statusAuthField]
+
+		log.Printf("Checking account %s", saEmail)
+
+		// at this point it's only allowed / considered authentication using the provided service account key.
+		// if running inside GCP there will be multiple ACTIVE SAs: the ones of the service this application
+		// is running on (GKE)
+		if status == saStatusActive && (saEmail == providedSaEmail) {
+			log.Printf("Already authenticated for %s", saEmail)
+			return true
+		}
+	}
+	log.Printf("Authentication is needed for SA: %s", providedSaEmail)
+	return false
 }

--- a/internal/gcp/auth.go
+++ b/internal/gcp/auth.go
@@ -1,9 +1,24 @@
 package gcp
 
+import "github.com/iac-io/myiac/internal/commandline"
+
 type ServiceAccountAuth struct {
 	serviceAccountKey ServiceAccountKey
+	commandRunner     commandline.CommandRunner
 }
 
 func NewServiceAccountAuth(keyLocation string) {
+
+}
+
+func newServiceAccountAuthWithRunner(commandRunner commandline.CommandRunner, keyLocation string) {
+
+}
+
+func Authenticate() {
+
+}
+
+func IsAuthenticated() {
 
 }

--- a/internal/gcp/auth.go
+++ b/internal/gcp/auth.go
@@ -12,6 +12,7 @@ const (
 	saStatusActive        = "ACTIVE"
 	statusAuthField       = "status"
 	emailAccountAuthField = "account"
+	listAuthCmd           = "gcloud auth list --format json -q"
 )
 
 type Auth interface {
@@ -58,9 +59,9 @@ func (saa ServiceAccountAuth) Key() *ServiceAccountKey {
 }
 
 func (saa ServiceAccountAuth) listActiveAuth() []map[string]interface{} {
-	cmdLine := fmt.Sprintf("gcloud auth list --format json")
-	cmd := commandline.NewCommandLine(cmdLine)
-	cmdOutput := cmd.Run()
+	cmdLine := fmt.Sprintf(listAuthCmd)
+	saa.commandRunner.SetupCmdLine(cmdLine)
+	cmdOutput := saa.commandRunner.Run()
 	authList := util.ParseArray(cmdOutput.Output)
 	return authList
 }

--- a/internal/gcp/auth.go
+++ b/internal/gcp/auth.go
@@ -1,0 +1,9 @@
+package gcp
+
+type ServiceAccountAuth struct {
+	serviceAccountKey ServiceAccountKey
+}
+
+func NewServiceAccountAuth(keyLocation string) {
+
+}

--- a/internal/gcp/auth_test.go
+++ b/internal/gcp/auth_test.go
@@ -1,0 +1,95 @@
+package gcp
+
+import (
+	"log"
+	"testing"
+
+	"github.com/iac-io/myiac/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	statusActiveJson = `
+	[
+	  {
+		"account": "testAccount@testProject.iam.gserviceaccount.com",
+		"status": "ACTIVE"
+	  },
+	  {
+		"account": "otherAccount@testProject.iam.gserviceaccount.com",
+		"status": ""
+	  }
+	]
+	`
+
+	statusNotActiveJson = `
+	[
+	  {
+		"account": "testAccount@testProject.iam.gserviceaccount.com",
+		"status": ""
+	  },
+	  {
+		"account": "otherAccount@testProject.iam.gserviceaccount.com",
+		"status": "ACTIVE"
+	  }
+	]
+	`
+	statusEmptyJson = "[]"
+
+	//TODO: throws unmarshalling error, should be captured?
+	statusEmptyString = ""
+)
+
+//func TestAuthenticatesWhenValidSa(t *testing.T) {
+//	testAccountKeyPath := "../../testdata/test_account.json"
+//	accountKey, _ := NewServiceAccountKey(testAccountKeyPath)
+//
+//	cmdLine := testutil.FakeCommandRunner("test-output")
+//	saAuth, err := newServiceAccountAuthWithRunner(cmdLine, accountKey)
+//
+//	if err != nil {
+//		log.Fatalf("error creating auth -- %s", err)
+//	}
+//
+//	saAuth.Authenticate()
+//
+//	cmdLineRun := cmdLine.GetCmdLines()[0]
+//	expectedCmdLine := fmt.Sprintf("gcloud auth activate-service-account --key-file %s", testAccountKeyPath)
+//	assert.Equal(t, expectedCmdLine, cmdLineRun)
+//}
+
+func TestChecksAuthDone(t *testing.T) {
+	testAccountKeyPath := "../../testdata/test_account.json"
+	accountKey, _ := NewServiceAccountKey(testAccountKeyPath)
+
+	cmdLine := testutil.FakeCommandRunner("default-output")
+	cmdLine.FakeCommand(listAuthCmd, statusActiveJson)
+
+	saAuth, err := newServiceAccountAuthWithRunner(cmdLine, accountKey)
+
+	if err != nil {
+		log.Fatalf("error creating auth -- %s", err)
+	}
+
+	isAuthenticated := saAuth.IsAuthenticated()
+
+	assert.Equal(t, true, isAuthenticated)
+}
+
+func TestChecksAuthNotDone(t *testing.T) {
+	testAccountKeyPath := "../../testdata/test_account.json"
+	accountKey, _ := NewServiceAccountKey(testAccountKeyPath)
+
+	cmdLine := testutil.FakeCommandRunner("defaultOutput")
+	cmdLine.FakeCommand(listAuthCmd, statusNotActiveJson)
+
+	saAuth, err := newServiceAccountAuthWithRunner(cmdLine, accountKey)
+
+	if err != nil {
+		log.Fatalf("error creating auth -- %s", err)
+	}
+
+	isAuthenticated := saAuth.IsAuthenticated()
+
+	assert.Equal(t, false, isAuthenticated)
+}

--- a/internal/gcp/auth_test.go
+++ b/internal/gcp/auth_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	_ "github.com/iac-io/myiac/testing"
 	"github.com/iac-io/myiac/testutil"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/gcp/auth_test.go
+++ b/internal/gcp/auth_test.go
@@ -3,8 +3,10 @@ package gcp
 import (
 	"fmt"
 	"log"
+	"os"
 	"testing"
 
+	_ "github.com/iac-io/myiac/testing"
 	"github.com/iac-io/myiac/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,13 +39,40 @@ const (
 	`
 	statusEmptyJson = "[]"
 
-	//TODO: throws unmarshalling error, should be captured?
-	statusEmptyString = ""
+	testAccountKeyJson = `
+{
+  "type": "service_account",
+  "project_id": "testProject",
+  "private_key_id": "45cc80629bd8fd2d018ff005f708bd3faa1bca45",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nIAABoGIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDIUXZKCIOzduR9\nMpXm8d2eEtD7dbMTaIWKj95MflJpgJzGuCWTg5g79U0gRARW+5h1bQFbIyIe4NYZ\nCNkItLLwYb34aAZc98yb7ulu0oZ41fZ0OOTOPPQZrX0CZaev2kIxYpzKNYqiT/b3\ngjmUTBhuY/sXJAJ/qzgRX0MoYXwDoZ9CeRF3NKwLdp4jNnXMRsGEXgVKEzm3hNmX\nP4lQKjj9H2+Gig93WCUZN6lbfdbp/13kMpzT0+cw6XTsdzLHYOotM3miadNCGIt0\n53oouHJeQ5PSuFzQszYbSe3tdm8BMYLdQiQog50quxmkU2VXxUJplLQhGaIXgQ3p\nVn/bG36dAgMBAAECggEAGbuDNUPuPSfU9rNAl+PyituSbncCa8gVvYS5MvzYM9bS\nbOGbbB1vuSYMBAzQvObBgTYhQjaba7mIrzsYfDqQMPpxV59vT9KCPXa9lF+laBDe\nQbRMSiUA22qSoDP0TE3+ik8HYp9poWuhx046fM8gpU+hIeodiw5w26Rv4VhSgLmw\nOF6yUx2po/cQdz0/+qScu82D3MnEtfdm8GWBSu5NU+lT4wvrCa8RxGoZ8cCsGDJn\n3qTn6f9qzSMgZcd4Sb2LGw5/UbpL43uUmWCRVMR/yCBFdYFG48rPzD8Nb8DZCjLD\nXOM3Crx20+vSI2/Itb34/Fju5v11whFdhhwBpRajgQKBgQD1WLQdklQs9FtboxfR\nv6930zgjfv1LBx9uR7qZy8f7F1fLBRW1BeVyNiGjRs3ONj0g059KhP6F60pM6iN5\nq28Zf0MpPzSpZ47J/emVkUIBGoy71tDWirAUpriUbTljzGAzRXSBySSr6U70cg+l\n7QE1DK+9vlW2BxgptWtX65JRgQKBgQDRBDgxvh82oYbJIbPyVL9Dak3jABsveXPX\n2/Y3TjVdz+0/pSb2KTmb0LNaYnvXv6+3xLS5KM4xy5pZyGNV8PXAByF6/Ya+1pvY\nnz1dLFjQzbp1rkPJWiTdsEtUM1mYivKTZC7KfX14bItlSBmkmJvBFs5BSpo9b5dz\njGIPWvPDHQKBgGn6gAsKC0xD3TavM3nJ+CylU2mZ0CXZlM0ZNNR8Pw0KH0U2FBNW\n0a7NDSivS/UYXr1QTE1vN1Z3tWeV9+71i48S9trZT5Ehh39fK8gMr9s0Mbht6VXT\nII47Gh4bNCAUxzU+ej4Zubp8lDtpDbNZthzJNxyaHAH9/IT/tbeLrW+BAoGASZSB\nr8ktNc8xItcRgOqiljnzB0l/SHwp8sCFcby/frH25CPgjmG+3QJgUR5AWJgrZLcD\no/cgd1kkkhzAE34LFTmtaJ2ddMsZ++067fTxozf5PvpE9LoeJkisjAyzqsanVIm9\nCx2YMO+NNu9lz5LFqfi8TTHVEHGbUFsIHj23eGUCgYBPIKpfee5ywRLpc5Rg2V6V\nY0wB4dmO1hYnY18XUm2xaWWEOfhiK9SDObUhmNWSRJ6dZCPR2shcYGa5Ew+LxGuS\nQV8eMQYw8PcwxFzNsU4Q4s2IucWGH5D0G7wFQys+ZqB1tYdvvMbQTOQ9X4R/Qc54\nWbyS1uABSbQxTCFNj0Fabc==\n-----END PRIVATE KEY-----\n",
+  "client_email": "testAccount@testProject.iam.gserviceaccount.com",
+  "client_id": "1000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testAccount%40testProject.iam.gserviceaccount.com"
+}
+`
+	testAccountKeyPath = "/tmp/test_account.json"
 )
 
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}
+
+func setup() {
+	WriteSaKeyToString(testAccountKeyPath)
+}
+
+func cleanup() {
+	_ = os.Remove(testAccountKeyPath)
+}
+
 func TestAuthenticatesWhenValidSa(t *testing.T) {
-	testAccountKeyPath := "../../testdata/test_account.json"
-	accountKey, _ := NewServiceAccountKey(testAccountKeyPath)
+	accountKey, _ := NewServiceAccountKey("/tmp/test_account.json")
 
 	cmdLine := testutil.FakeCommandRunner("test-output")
 	saAuth, err := newServiceAccountAuthWithRunner(cmdLine, accountKey)
@@ -60,7 +89,6 @@ func TestAuthenticatesWhenValidSa(t *testing.T) {
 }
 
 func TestAuthNotDone(t *testing.T) {
-	testAccountKeyPath := "../../testdata/test_account.json"
 	accountKey, _ := NewServiceAccountKey(testAccountKeyPath)
 	cmdLine := testutil.FakeCommandRunner("defaultOutput")
 

--- a/internal/gcp/service_account_key.go
+++ b/internal/gcp/service_account_key.go
@@ -12,21 +12,21 @@ type ServiceAccountKey struct {
 	Email           string
 }
 
-func NewServiceAccountKey(keyLocationn string) (*ServiceAccountKey, error) {
-	ok, err := isValidKeyLocation(keyLocationn)
+func NewServiceAccountKey(keyLocation string) (*ServiceAccountKey, error) {
+	ok, err := isValidKeyLocation(keyLocation)
 
 	if !ok {
-		log.Printf("error validating key -- this is required")
+		log.Printf("error validating key -- this is required %s", err)
 		return nil, err
 	}
 
-	saEmail, err := extractSaEmailFromKey(keyLocationn)
+	saEmail, err := extractSaEmailFromKey(keyLocation)
 
 	if err != nil {
 		log.Printf("error: email could not be obtained from key at location %s", saEmail)
 	}
 
-	return &ServiceAccountKey{KeyFileLocation: keyLocationn, Email: saEmail}, nil
+	return &ServiceAccountKey{KeyFileLocation: keyLocation, Email: saEmail}, nil
 }
 
 func extractSaEmailFromKey(keyLocation string) (string, error) {

--- a/internal/gcp/service_account_key.go
+++ b/internal/gcp/service_account_key.go
@@ -1,0 +1,51 @@
+package gcp
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/iac-io/myiac/internal/util"
+)
+
+type ServiceAccountKey struct {
+	KeyFileLocation string
+	Email           string
+}
+
+func NewServiceAccountKey(keyLocationn string) (*ServiceAccountKey, error) {
+	ok, err := isValidKeyLocation(keyLocationn)
+
+	if !ok {
+		log.Printf("error validating key -- this is required")
+		return nil, err
+	}
+
+	saEmail, err := extractSaEmailFromKey(keyLocationn)
+
+	if err != nil {
+		log.Printf("error: email could not be obtained from key at location %s", saEmail)
+	}
+
+	return &ServiceAccountKey{KeyFileLocation: keyLocationn, Email: saEmail}, nil
+}
+
+func extractSaEmailFromKey(keyLocation string) (string, error) {
+	json, err := util.ReadFileToString(keyLocation)
+
+	if err != nil {
+		return "", fmt.Errorf("error reading key location %s", err)
+	}
+
+	keyJson := util.Parse(json)
+	saEmail := util.GetStringValue(keyJson, "client_email")
+
+	log.Printf("Service account email in JSON key is: %s", saEmail)
+	return saEmail, nil
+}
+
+func isValidKeyLocation(keyLocation string) (bool, error) {
+	if !util.FileExists(keyLocation) {
+		return false, fmt.Errorf("key path is invalid %s\n", keyLocation)
+	}
+	return true, nil
+}

--- a/internal/gcp/service_account_key_test.go
+++ b/internal/gcp/service_account_key_test.go
@@ -1,0 +1,34 @@
+package gcp
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidKeyWithValidEmail(t *testing.T) {
+	testAccountKeyPath := "../../testdata/test_account.json"
+	accountEmail := "testAccount@testProject.iam.gserviceaccount.com"
+	accountKey, err := NewServiceAccountKey(testAccountKeyPath)
+
+	if err != nil {
+		log.Fatalf("error creating service account key account %s", err)
+	}
+
+	assert.Equal(t, accountEmail, accountKey.Email)
+}
+
+func TestInvalidValidKeyLocationFails(t *testing.T) {
+	testAccountKeyPath := "test_account.json"
+	_, err := NewServiceAccountKey(testAccountKeyPath)
+
+	if err != nil {
+		errMessage := fmt.Sprintf("%s", err)
+		assert.Contains(t, errMessage, "key path is invalid")
+		return
+	}
+
+	assert.Fail(t, "key location is invalid -- test should've failed")
+}

--- a/internal/gcp/service_account_key_test.go
+++ b/internal/gcp/service_account_key_test.go
@@ -5,11 +5,13 @@ import (
 	"log"
 	"testing"
 
+	"github.com/iac-io/myiac/internal/util"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestValidKeyWithValidEmail(t *testing.T) {
-	testAccountKeyPath := "../../testdata/test_account.json"
+
 	accountEmail := "testAccount@testProject.iam.gserviceaccount.com"
 	accountKey, err := NewServiceAccountKey(testAccountKeyPath)
 
@@ -31,4 +33,13 @@ func TestInvalidValidKeyLocationFails(t *testing.T) {
 	}
 
 	assert.Fail(t, "key location is invalid -- test should've failed")
+}
+
+// util
+func WriteSaKeyToString(testAccountKeyPath string) {
+	err := util.WriteStringToFile(testAccountKeyJson, testAccountKeyPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return
 }

--- a/internal/gcp/service_account_key_test.go
+++ b/internal/gcp/service_account_key_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/iac-io/myiac/internal/util"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/gcp/service_account_test.go
+++ b/internal/gcp/service_account_test.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,11 +82,6 @@ func (m *fakeObjectStorageCache) Write(ctx context.Context, bucketName string, k
 func (m fakeObjectStorageCache) Read(ctx context.Context, bucketName string, objectKey string) (interface{}, error) {
 	args := m.Called(ctx, bucketName, objectKey)
 	return args.Get(0).(interface{}), args.Error(1)
-}
-
-func TestMain(m *testing.M) {
-	code := m.Run()
-	os.Exit(code)
 }
 
 func TestCreateNewKey(t *testing.T) {

--- a/internal/preferences/preferences.go
+++ b/internal/preferences/preferences.go
@@ -18,6 +18,7 @@ type Preferences interface {
 	Set(name string, value string)
 	Get(name string) string
 	Del(name string)
+	SetMultiple(preferencesSet map[string]string)
 }
 
 type configPreferences struct {
@@ -72,6 +73,12 @@ func (prefs configPreferences) Get(name string) string {
 
 func (prefs configPreferences) Del(name string) {
 	prefs.propertiesFile.Section("").DeleteKey(name)
+}
+
+func (prefs configPreferences) SetMultiple(preferencesSet map[string]string) {
+	for key, value := range preferencesSet {
+		prefs.Set(key, value)
+	}
 }
 
 func createPath(p string) (*os.File, error) {

--- a/internal/preferences/preferences_test.go
+++ b/internal/preferences/preferences_test.go
@@ -43,6 +43,22 @@ func TestSetsProperty(t *testing.T) {
 	assert.Contains(t, prefsFileContent, "testValue")
 }
 
+func TestSetsMultipleProperties(t *testing.T) {
+	prefs := NewConfig(prefsFilename)
+
+	multipleProps := make(map[string]string)
+	multipleProps["testProperty"] = "testValue"
+	multipleProps["testAnotherProperty"] = "testAnotherValue"
+	prefs.SetMultiple(multipleProps)
+
+	prefsFileContent, _ := util.ReadFileToString(prefsFilename)
+	fmt.Printf("Contents %v", prefsFileContent)
+	assert.Contains(t, prefsFileContent, "testProperty")
+	assert.Contains(t, prefsFileContent, "testValue")
+	assert.Contains(t, prefsFileContent, "testAnotherProperty")
+	assert.Contains(t, prefsFileContent, "testAnotherValue")
+}
+
 func TestGetsProperty(t *testing.T) {
 	prefs := NewConfig(prefsFilename)
 	prefs.Set("testProperty", "testValue")

--- a/internal/secret/kubernetes_secret_runner_test.go
+++ b/internal/secret/kubernetes_secret_runner_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCreateFileSecret(t *testing.T) {
 	// setup
-	cmdLine := testutil.FakeKubernetesRunner("secret default/test-secret created")
+	cmdLine := testutil.FakeCommandRunner("secret default/test-secret created")
 	kubernetesRunner := NewKubernetesRunner(cmdLine)
 
 	// given

--- a/internal/secret/secret_manager_test.go
+++ b/internal/secret/secret_manager_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCreateSecret(t *testing.T) {
 	// setup
-	cmdLine := testutil.FakeKubernetesRunner("test-output")
+	cmdLine := testutil.FakeCommandRunner("test-output")
 	kubernetesRunner := NewKubernetesRunner(cmdLine)
 	secretManager := NewKubernetesSecretManager("default", kubernetesRunner)
 

--- a/internal/ssl/certificate_test.go
+++ b/internal/ssl/certificate_test.go
@@ -12,7 +12,7 @@ import (
 func TestCreateTlsCertificate(t *testing.T) {
 	// setup
 	domain := "test-domain"
-	cmdLine := testutil.FakeKubernetesRunner(domain)
+	cmdLine := testutil.FakeCommandRunner(domain)
 	kubernetesRunner := secret.NewKubernetesRunner(cmdLine)
 	secretManager := secret.NewKubernetesSecretManager("default", kubernetesRunner)
 

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,0 +1,1 @@
+package testing

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -1,1 +1,0 @@
-package testing

--- a/testutil/fake_cmd_runner.go
+++ b/testutil/fake_cmd_runner.go
@@ -22,18 +22,16 @@ func (fk *fakeRunner) SetupWithoutOutput(cmd string, args []string) {
 }
 
 func (fk *fakeRunner) Run() commandline.CommandOutput {
-	//currentCmdLine := fk.cmd + " " + strings.Join(fk.args, " ")
-	//fk.CmdLines = append(fk.CmdLines, currentCmdLine)
+	currentCmdLine := fk.cmd + " " + strings.Join(fk.args, " ")
+	fk.CmdLines = append(fk.CmdLines, currentCmdLine)
 
 	// every time we call Run(), check the cmdLine and return the
 	// corresponding output
 	if currentOutput, ok := fk.cmdLineToOutput[fk.currentCmdLine]; ok {
 		fk.output = currentOutput
-		fmt.Printf("output is \n %s", currentOutput)
 		return commandline.CommandOutput{Output: currentOutput}
 	}
 
-	fmt.Printf("output is \n %s", fk.currentCmdLine)
 	// default output
 	return commandline.CommandOutput{Output: fk.output}
 }


### PR DESCRIPTION
- Fixes #72 - The provided key used, even in GCP, and the other active auth/s are ignored/considered unauthenticated
- Extraction of authentication concern out of `provider.go` into `gcp` package - `auth.go`
- Add private constructors in lowercase that always receive a `commandRunner` so it can be faked in tests
- Tested basic setup works

Tests:
- Coverage dropped a lot so had to backfill this `auth` testing quite a lot. Coverage is now up 4% in general as a result.
- Added `FakeCommand(cmd, output)` functionality to the utilities. This allows to mock a command line with its output. When calling `SetupCmdLine`, a `cmd` is set as `current`, when executing `Run()` the expected `output` is returned. This way is much easier to write tests that don't run any sort of real command in shells - just give the `cmdLine` and its expected `output`. This will be extended with multiple ones.

TODO:
- [x] Tests not present - need to clear `testdata` fake json key as in CI the path of files is not predictable (had to use `/tmp`)
- [x] Self review not done