### PR TITLE
fix: Docker Hub Login moved to use actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build Docker Image
 
 on:
   push:
-    branches: [ docker/*, fix/* ]
+    branches: [ docker/* ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build Docker Image
 
 on:
   push:
-    branches: [ docker/* ]
+    branches: [ docker/*, fix/* ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,3 +42,4 @@ jobs:
         run: |
           docker tag polinux/myiac:latest polinux/myiac:stage
           docker push polinux/myiac:stage
+          docker images

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -32,8 +32,13 @@ jobs:
           docker run -i --rm polinux/myiac:latest helm version
           docker run -i --rm polinux/myiac:latest gcloud version
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASS }}
+
       - name: Stage image
         run: |
           docker tag polinux/myiac:latest polinux/myiac:stage
-          docker login  -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASS }}
           docker push polinux/myiac:stage

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,4 +42,3 @@ jobs:
         run: |
           docker tag polinux/myiac:latest polinux/myiac:stage
           docker push polinux/myiac:stage
-          docker images

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -16,9 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASS }}
+
       - name: Publish image
         run: |
-          docker login  -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASS }}
           docker pull polinux/myiac:stage
           docker tag polinux/myiac:stage polinux/myiac:latest
           docker tag polinux/myiac:latest polinux/myiac:h${HELM_V}-t${TERRAFORM_V}


### PR DESCRIPTION
TTY is noi longer working with GitHub Actions. Moved login to use official `docker/login@v1` actions